### PR TITLE
MAINT: define __version__

### DIFF
--- a/macop/__init__.py
+++ b/macop/__init__.py
@@ -27,3 +27,5 @@ from macop.solutions import continuous
 from macop.solutions import discrete
 
 from macop.utils import progress
+
+__version__ = "v1.0.16"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup
 import distutils.command.check
+import macop
 
 class TestCommand(distutils.command.check.check):
     """Custom test command."""
@@ -82,7 +83,7 @@ class TestCommand(distutils.command.check.check):
 
 setup(
     name='macop',
-    version='1.0.16',
+    version=macop.__version__,
     description='Minimalist And Customisable Optimisation Package',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
**What does this PR implement?**
Following Python community standards, "For example, in accordance with this PEP, [versions] are available programmatically on the module's `__version__` attribute" ([PEP 396, "Deriving"][1]).

[1]:https://www.python.org/dev/peps/pep-0396/#deriving